### PR TITLE
bug fixed - forgotten @run_in_reactor decorator added to set_port_han…

### DIFF
--- a/storjnode/network/server.py
+++ b/storjnode/network/server.py
@@ -140,6 +140,7 @@ class Server(KademliaServer):
             self._refresh_thread = threading.Thread(target=self._refresh_loop)
             self._refresh_thread.start()
 
+    @run_in_reactor
     def set_port_handler(self, port_handler):
         self.port_handler = port_handler
 


### PR DESCRIPTION
@run_in_reactor decorator added because of twisted reactor threading
