### PR TITLE
bug fixed - forgotten @run_in_reactor decorator added to set_port_handler

### DIFF
--- a/storjnode/network/server.py
+++ b/storjnode/network/server.py
@@ -140,6 +140,7 @@ class Server(KademliaServer):
             self._refresh_thread = threading.Thread(target=self._refresh_loop)
             self._refresh_thread.start()
 
+    @run_in_reactor
     def set_port_handler(self, port_handler):
         self.port_handler = port_handler
 

--- a/tests/network/server_test.py
+++ b/tests/network/server_test.py
@@ -1,4 +1,5 @@
 import unittest
+import storjnode
 from storjnode.network.server import Server
 
 
@@ -12,7 +13,7 @@ class TestServer(unittest.TestCase):
         # create server and start listen on port 12345
         test_result = True
         key = "5KaasrJx9KQymQ4zMffEPrsHxSn1bCnM9c3tbicp4Uunf1nrzyM"
-        port = 12345
+        port = storjnode.util.get_unused_port(None)
         server1 = Server(key, port)
         port_handler = server1.listen(port)
         server1.set_port_handler(port_handler)


### PR DESCRIPTION
@run_in_reactor decorator added because of reactor threading
and unittest fix for testing server - port closing
