### PR TITLE
Enchacement: Use smarter algorithm to find next available predictable key when saving monitor results

### DIFF
--- a/tests/network/node.py
+++ b/tests/network/node.py
@@ -435,6 +435,38 @@ class TestNode(unittest.TestCase):
         print("CRAWLED DATA", crawl_data)
         self.assertEqual(len(crawl_data["processed"]), limit)
 
+    #####################################################
+    # test of searching unused slot for shard id in DHT #
+    #####################################################
+
+    def test_find_next_free_dataset_num(self):
+        rp = random.choice(self.swarm)
+        # test 20 slots
+        x_times = 20
+        d_num = [0] * x_times
+        start_time = time.time()
+        for i in range(0, x_times):
+            print(" ")
+            watch_time = time.time()
+            num = storjnode.network.monitor.find_next_free_dataset_num(rp)
+            key = storjnode.network.monitor.predictable_key(rp, num)
+            # write num to array so we can use it for test later
+            d_num[i] = num
+            # write num also to DHT slot so we can test it later
+            rp[key] = num
+            print("Searching time: %ss" % (time.time() - watch_time))
+        print(" ")
+        print("Total searching time: %ss" % (time.time() - start_time))
+        test_result = True
+        for i in range(0, x_times):
+            num = d_num[i]
+            key = storjnode.network.monitor.predictable_key(rp, num)
+            # test if slot is used with correct value of num, else error
+            if rp[key] is None or rp[key] is not num:
+                test_result = False
+                break
+        self.assertTrue(test_result)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/network/server_test.py
+++ b/tests/network/server_test.py
@@ -10,7 +10,7 @@ class TestServer(unittest.TestCase):
     ##################################
 
     def test_server_port_closing(self):
-        # create server and start listen on port 12345
+        # create server and start listen on some random port
         test_result = True
         key = "5KaasrJx9KQymQ4zMffEPrsHxSn1bCnM9c3tbicp4Uunf1nrzyM"
         port = storjnode.util.get_unused_port(None)


### PR DESCRIPTION
Exponential probing and binary search for unused slot.
Also all unit test are done.
If you dont like long test you can 
tests/network/node.py
find function with name
test_find_next_free_dataset_num
and you can set the value of variable
x_times = 20
to lower value which does shorter test.
